### PR TITLE
Add LanguageTypeCode and Test

### DIFF
--- a/src/main/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/LanguageTypeCode.java
+++ b/src/main/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/LanguageTypeCode.java
@@ -1,0 +1,41 @@
+package th.ac.kmitl.it.soa.group5.etaxinvoice.definitions;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum LanguageTypeCode {
+
+    THAI ("tha", "ภาษาไทย"),
+    ENGLISH ("eng", "ภาษาอังกฤษ"),
+    CHINESE ("chi", "ภาษาจีน"),
+    JAPAN ("jpn", "ภาษาญี่ปุ่น"),
+    SPAIN ("spa", "ภาษาสเปน"),
+    GERMAN ("ger", "ภาษาเยอรมัน");
+
+    private @Getter String languageCode;
+    private @Getter String languageName;
+
+    LanguageTypeCode(String languageCode, String languageName) {
+        this.languageCode = languageCode;
+        this.languageName = languageName;
+    }
+
+    public static Map<String, LanguageTypeCode> mapper = new HashMap<>();
+    static {
+        for (LanguageTypeCode languageTypeCode : LanguageTypeCode.values()) {
+            mapper.put(languageTypeCode.getLanguageCode(), languageTypeCode);
+        }
+    }
+
+    public static LanguageTypeCode parse(String languageCode) {
+        LanguageTypeCode languageTypeCode = mapper.get(languageCode);
+
+        if (languageTypeCode == null) {
+            throw new IllegalArgumentException("There is no value with name " + languageCode);
+        }
+
+        return mapper.get(languageCode);
+    }
+}

--- a/src/test/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/LanguageTypeCodeTest.java
+++ b/src/test/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/LanguageTypeCodeTest.java
@@ -1,0 +1,35 @@
+package th.ac.kmitl.it.soa.group5.etaxinvoice.definitions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LanguageTypeCodeTest {
+
+    @Test
+    public void shouldGetCorrectCode(){
+        assertEquals(LanguageTypeCode.THAI, LanguageTypeCode.parse("tha"));
+        assertEquals(LanguageTypeCode.ENGLISH, LanguageTypeCode.parse("eng"));
+        assertEquals(LanguageTypeCode.CHINESE, LanguageTypeCode.parse("chi"));
+        assertEquals(LanguageTypeCode.JAPAN, LanguageTypeCode.parse("jpn"));
+        assertEquals(LanguageTypeCode.SPAIN, LanguageTypeCode.parse("spa"));
+        assertEquals(LanguageTypeCode.GERMAN, LanguageTypeCode.parse("ger"));
+    }
+
+    @Test
+    public void shouldGetCorrectName(){
+        assertEquals(LanguageTypeCode.THAI.getLanguageName(), "ภาษาไทย");
+        assertEquals(LanguageTypeCode.ENGLISH.getLanguageName(), "ภาษาอังกฤษ");
+        assertEquals(LanguageTypeCode.CHINESE.getLanguageName(), "ภาษาจีน");
+        assertEquals(LanguageTypeCode.JAPAN.getLanguageName(), "ภาษาญี่ปุ่น");
+        assertEquals(LanguageTypeCode.SPAIN.getLanguageName(), "ภาษาสเปน");
+        assertEquals(LanguageTypeCode.GERMAN.getLanguageName(), "ภาษาเยอรมัน");
+    }
+
+    @Test
+    public void shouldThrowException(){
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> LanguageTypeCode.parse("XXX"));
+    }
+}

--- a/src/test/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/ReferenceTypeCodeTest.java
+++ b/src/test/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/ReferenceTypeCodeTest.java
@@ -1,4 +1,4 @@
-package th.ac.kmitl.it.soa.group5.etaxinvoice;
+package th.ac.kmitl.it.soa.group5.etaxinvoice.definitions;
 
 import org.junit.Test;
 import th.ac.kmitl.it.soa.group5.etaxinvoice.definitions.ReferenceTypeCode;

--- a/src/test/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/TaxPayerIdTypeCodeTest.java
+++ b/src/test/java/th/ac/kmitl/it/soa/group5/etaxinvoice/definitions/TaxPayerIdTypeCodeTest.java
@@ -1,4 +1,4 @@
-package th.ac.kmitl.it.soa.group5.etaxinvoice;
+package th.ac.kmitl.it.soa.group5.etaxinvoice.definitions;
 
 import org.junit.Test;
 import th.ac.kmitl.it.soa.group5.etaxinvoice.definitions.TaxPayerIdTypeCode;


### PR DESCRIPTION
Refactor : Moved TaxPayerIdTypeCodeTest.java and ReferenceTypeCodeTest.java to Package th.ac.kmitl.it.soa.group5.etaxinvoice.definitions

Add LanguageTypeCode.java and LanguageTypeCodeTest.java
ตามเอกสารหน้าที่ 51